### PR TITLE
Fixed some issues with .navbar-right

### DIFF
--- a/CONTRIBUTERS.md
+++ b/CONTRIBUTERS.md
@@ -7,4 +7,5 @@ Template:
 ### Contributors:
 
 2013/08/02, morteza, Morteza Ansarinia, ansarinia@me.com
+2014/06/13, jayclassless, Jason Simeone, jay@classless.net
 

--- a/less/navbar-rtl.less
+++ b/less/navbar-rtl.less
@@ -84,9 +84,20 @@
       float: right;
     }
 
-    &.navbar-right:last-child {
-      margin-left: -@navbar-padding-horizontal;
-      margin-right: auto;
+    &.navbar-right {
+      &:last-child {
+        margin-left: -@navbar-padding-horizontal;
+        margin-right: auto;
+      }
+
+      &.flip {
+        float: left !important;
+      }
+
+      .dropdown-menu {
+        left: 0;
+        right: auto;
+      }
     }
   }
 }


### PR DESCRIPTION
Greetings. In this PR I fixed a couple issues I encountered with navbars when trying to use bootstrap-rtl.
1. I added `.flip` support to the `.navbar-right` class so that it would pin to the side of the screen as it would in non-rtl mode. (It's the navbar equivalent of `.pull-right`)
2. I adjusted the positioning of dropdown menu items under a `.navbar-right` so that they wouldn't appear half off-screen.
