### PR TITLE
Add support to navbar-right and navbar-left

### DIFF
--- a/dist/css/bootstrap-rtl.css
+++ b/dist/css/bootstrap-rtl.css
@@ -1158,8 +1158,14 @@ th {
   .navbar-nav {
     float: right;
   }
+  .navbar-right {
+    float: left !important;
+  }
+  .navbar-left {
+    float: right !important;
+  }
   .navbar-nav > li {
-    float: right;
+    float: right !important;
   }
 }
 @media (min-width: 768px) {

--- a/less/navbar-rtl.less
+++ b/less/navbar-rtl.less
@@ -81,7 +81,7 @@
     float: right;
 
     > li {
-      float: right;
+      float: right !important;
     }
 
   }
@@ -89,13 +89,14 @@
 
 @media (min-width: @grid-float-breakpoint) {
   .navbar-left {
-
+    float: right !important;
     &.flip {
       float: right !important;
     }
   }
 
   .navbar-right {
+    float: left !important;
     &:last-child {
       margin-left: -@navbar-padding-horizontal;
       margin-right: auto;


### PR DESCRIPTION
When using navbar-left or navbar-right the Bootstrap declaration takes precedence because they use !important.

This resolves the issue.

Thanks :)