### PR TITLE
add mirrored version of .text-left and .text-right

### DIFF
--- a/less/utilities-rtl.less
+++ b/less/utilities-rtl.less
@@ -13,3 +13,9 @@
     float: right !important;
   }
 }
+.text-left {
+  text-align: right !important;
+}
+.text-right {
+  text-align: left !important;
+}


### PR DESCRIPTION
currently using .text-right and .text-left has no effect as they are overridden by other rules in bootstrap-rtl.
so this PR shall fix it,
and feel free to reverse the mirroring and keep .text-left as left align and vice versa