### PR TITLE
update bootstrap-rtl.min.css

### DIFF
--- a/dist/css/bootstrap-rtl.css
+++ b/dist/css/bootstrap-rtl.css
@@ -1050,7 +1050,7 @@ th {
 }
 .input-group-addon:first-child {
   border-left: 0px;
-  border-right: 1px solid;
+  border-right: 1px solid #ccc;
 }
 .input-group .form-control:last-child,
 .input-group-addon:last-child,


### PR DESCRIPTION
Added #ccc to the right border in input-group addon, it was black by default.
![pn](https://cloud.githubusercontent.com/assets/11773373/14017847/83418404-f1ca-11e5-92dd-9b02a17ea127.png)
