### PR TITLE
Updated dropdown position

### DIFF
--- a/less/dropdowns-rtl.less
+++ b/less/dropdowns-rtl.less
@@ -10,8 +10,8 @@
 
 // The dropdown menu (ul)
 .dropdown-menu {
-  right: 0;
-  left: auto;
+  right: auto;
+  left: 0;
   float: left;
   text-align: right; // Ensures proper alignment if parent has it changed (e.g., modal footer)
 


### PR DESCRIPTION
In LTR layout dropdowns are aligned right, so in RTL they should be aligned left.