### PR TITLE
RTL direction removed from html tag

### DIFF
--- a/less/normalize-rtl.less
+++ b/less/normalize-rtl.less
@@ -2,14 +2,6 @@
 // 1. Set direction to RTL
 //
 
-html {
-  direction: rtl;
-}
-
-//
-// Remove default margin.
-//
-
 body {
   direction: rtl;
 }


### PR DESCRIPTION
Giving direction equals rtl to the html tag will cause scroll performance issues in the chrome browser.
For see an online example open this site and change `html` `direction` to `rtl` in the developer inspector and see the result.
3s-pars.com
or
radan-ir.com